### PR TITLE
[Feat] 고민 선택지 개수별 고민 카드 셀 높이 조정

### DIFF
--- a/HARA/HARA/Sources/Scenes/Together/TogetherVC.swift
+++ b/HARA/HARA/Sources/Scenes/Together/TogetherVC.swift
@@ -33,7 +33,11 @@ final class TogetherVC: UIViewController {
     
     /// 고민의 개수
     private var worryNums = 10
+    /// 선택지의 개수
+    private var optionNums = 2
     
+    
+    // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
         self.navigationController?.navigationBar.isHidden = true
@@ -74,7 +78,11 @@ extension TogetherVC: UICollectionViewDelegateFlowLayout {
             /// cell의 높이 값이 0이 나와서 상수에 adjustedH쓰는 것으로 대체
 //            let sizingCell = WorryCardCVC()
 //            let height = sizingCell.contentView.frame.height
-            return CGSize(width: CGFloat(336.adjustedW), height: CGFloat(383.adjustedH))
+            let width = collectionView.frame.width
+            /// 선택지 두개 일때(default) 13mini 기준 worryCardCVC의 높이 383 + optionNums - 기본 선택지 개수(2개)를 빼고 그 값에 여백 포함 셀 높이 50 계산하고 adjustedH
+            let height = CGFloat((339 + (optionNums-2)*50)).adjustedH
+            print(height)
+            return CGSize(width: width, height: height)
         }
     }
 }
@@ -102,6 +110,9 @@ extension TogetherVC: UICollectionViewDataSource {
             return cell
         }else if collectionView == worryCardCV {
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: WorryCardCVC.className, for: indexPath) as? WorryCardCVC else { return UICollectionViewCell() }
+            
+            /// VC의 optionNums를 cell의 optionNums에 전달
+            cell.setCellNums(optionNums: self.optionNums)
             return cell
         }else {
             return UICollectionViewCell()

--- a/HARA/HARA/Sources/Scenes/Together/TogetherVC.swift
+++ b/HARA/HARA/Sources/Scenes/Together/TogetherVC.swift
@@ -36,7 +36,7 @@ final class TogetherVC: UIViewController {
     /// 고민의 개수
     private var worryNums = 10
     private var worryTitles = ["고민1"]
-    private var worryContents = ["니ㅏ"]
+    private var worryContents = ["dsfsdfdsfdsf"]
     
     /// 선택지의 개수
     private var optionNums = 4

--- a/HARA/HARA/Sources/Scenes/Together/TogetherVC.swift
+++ b/HARA/HARA/Sources/Scenes/Together/TogetherVC.swift
@@ -23,18 +23,43 @@ final class TogetherVC: UIViewController {
         $0.collectionViewLayout = layout
     }
     
-    private let worryCardCV = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout()).then {
-        $0.backgroundColor = .clear
-        $0.showsVerticalScrollIndicator = false
-        $0.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 50, right: 0)
-    }
+    private lazy var worryCardCV: UICollectionView = {
+        let view = UICollectionView(frame: .zero, collectionViewLayout: self.compositionalLayout)
+        view.backgroundColor = .blue
+        view.showsVerticalScrollIndicator = false
+        view.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 50, right: 0)
+        return view
+    }()
     
     private let categoryTitles = ["전체", "일상", "연애", "패션/뷰티", "커리어", "운동", "여행", "기타"]
     
     /// 고민의 개수
     private var worryNums = 10
+    private var worryTitles = ["고민1"]
+    private var worryContents = ["니ㅏ"]
+    
     /// 선택지의 개수
-    private var optionNums = 2
+    private var optionNums = 4
+    
+    private lazy var compositionalLayout: UICollectionViewCompositionalLayout = {
+        let calculatedHeight = Double((self.optionNums*50 + 225)).adjustedH
+        let estimatedHeight = CGFloat(calculatedHeight)
+        let layoutSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(estimatedHeight))
+        let item = NSCollectionLayoutItem(layoutSize: layoutSize)
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: layoutSize, repeatingSubitem: item, count: 1)
+        
+//            item.edgeSpacing = NSCollectionLayoutEdgeSpacing(leading: nil, top: .fixed(10), trailing: nil, bottom: .fixed(10))
+//            item.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 10, trailing: 0)
+        
+//            group.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 10, trailing: 0)
+//            group.interItemSpacing = .flexible(-16)
+//
+        let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = 10
+//        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+        
+        return UICollectionViewCompositionalLayout(section: section)
+    }()
     
     
     // MARK: - View Life Cycle
@@ -62,6 +87,14 @@ final class TogetherVC: UIViewController {
         
         worryCardCV.register(cell: WorryCardCVC.self, forCellWithReuseIdentifier: WorryCardCVC.className)
     }
+    
+    func calculateLabelHeight(index: Int) -> CGFloat {
+        let label = UILabel()
+        label.text = worryContents[index]
+        label.font = .haraB2M14
+        return label.frame.height
+    }
+
 }
 // MARK: - UICollectionViewDelegateFlowLayout
 extension TogetherVC: UICollectionViewDelegateFlowLayout {
@@ -75,17 +108,21 @@ extension TogetherVC: UICollectionViewDelegateFlowLayout {
             let cellHeight = CGFloat(31)
             return CGSize(width: cellWidth, height: cellHeight)
         }else {
-            /// cell의 높이 값이 0이 나와서 상수에 adjustedH쓰는 것으로 대체
-//            let sizingCell = WorryCardCVC()
-//            let height = sizingCell.contentView.frame.height
-            let width = collectionView.frame.width
-            /// 선택지 두개 일때(default) 13mini 기준 worryCardCVC의 높이 383 + optionNums - 기본 선택지 개수(2개)를 빼고 그 값에 여백 포함 셀 높이 50 계산하고 adjustedH
-            let height = CGFloat((339 + (optionNums-2)*50)).adjustedH
-            print(height)
-            return CGSize(width: width, height: height)
+            
+//            let width = collectionView.frame.width
+//
+//            let contentHeight = calculateCellWidth(index: 0)
+//
+//            print("높이\(contentHeight)")
+//
+//            let height = CGFloat(optionNums*50 + Int(contentHeight) + 185)
+//
+//            return CGSize(width: width, height: height)
+            return .zero
         }
     }
 }
+
 
 // MARK: - UICollectionViewDataSource
 extension TogetherVC: UICollectionViewDataSource {
@@ -113,6 +150,7 @@ extension TogetherVC: UICollectionViewDataSource {
             
             /// VC의 optionNums를 cell의 optionNums에 전달
             cell.setCellNums(optionNums: self.optionNums)
+            cell.setData(title: worryTitles[0], content: worryContents[0])
             return cell
         }else {
             return UICollectionViewCell()
@@ -148,3 +186,4 @@ extension TogetherVC {
     }
     
 }
+

--- a/HARA/HARA/Sources/Scenes/Together/WorryCardCVC.swift
+++ b/HARA/HARA/Sources/Scenes/Together/WorryCardCVC.swift
@@ -33,17 +33,35 @@ class WorryCardCVC: UICollectionViewCell {
     private let worryContentLabel = UILabel().then {
         $0.textColor = .hBlack
         $0.font = .haraB2M14
-        $0.text = "1. 동해물과 백두산이 마르고 닳도록 하느님이 보우하사 우리나라 만세 무궁화 삼천리 화려 강산 대한 사람 대한으로 길이 보전하세 2. 남산 위에 저 소나무 철갑을 두른 듯 바..."
+        $0.text = "1. 동해물과 백두산이 마"
         $0.numberOfLines = 0
     }
     
-    private let voteOptionCV = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout()).then {
-        $0.isScrollEnabled = false
-        $0.backgroundColor = .yellow
-        $0.showsHorizontalScrollIndicator = false
-        $0.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+    private lazy var voteOptionCV: UICollectionView = {
+        let view = UICollectionView(frame: .zero, collectionViewLayout: self.compositionalLayout)
+        view.isScrollEnabled = false
+        view.backgroundColor = .yellow
+        view.showsHorizontalScrollIndicator = false
+        view.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+        return view
+    }()
+    
+    private lazy var compositionalLayout: UICollectionViewCompositionalLayout = {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(40))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+//        item.edgeSpacing = NSCollectionLayoutEdgeSpacing(leading: nil, top: .fixed(10), trailing: nil, bottom: .fixed(10))
+//        item.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 10, trailing: 0)
         
-    }
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(40))
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, repeatingSubitem: item, count: 1)
+                group.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 10, trailing: 0)
+        //        group.interItemSpacing = .flexible(-16)
+        let section = NSCollectionLayoutSection(group: group)
+        section.interGroupSpacing = 10
+        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+        
+        return UICollectionViewCompositionalLayout(section: section)
+    }()
     
     private let voteButton = UIButton().then {
         $0.setTitle("투표하기", for: .normal)
@@ -100,6 +118,11 @@ class WorryCardCVC: UICollectionViewCell {
     func setCellNums(optionNums: Int) {
         self.optionNums = optionNums
     }
+        
+    func setData(title: String, content: String) {
+        self.worryTitleLabel.text = title
+        self.worryContentLabel.text = content
+    }
 }
 
 // MARK: - UICollectionViewDataSource
@@ -146,7 +169,7 @@ extension WorryCardCVC {
         }
         
         worryTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(worryCategoryLabel.snp.bottom).offset(14)
+            $0.top.equalToSuperview().offset(44)
             $0.leading.equalToSuperview().offset(14)
             $0.trailing.equalToSuperview().inset(14)
             $0.height.equalTo(19.adjustedH)
@@ -156,7 +179,7 @@ extension WorryCardCVC {
             $0.top.equalTo(worryTitleLabel.snp.bottom).offset(8)
             $0.leading.equalToSuperview().offset(14)
             $0.trailing.equalToSuperview().inset(14)
-            $0.height.equalTo(66.adjustedH)
+//            $0.height.equalTo(66.adjustedH)
         }
         
         voteOptionCV.snp.makeConstraints {
@@ -176,7 +199,7 @@ extension WorryCardCVC {
 
         chatButton.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(15)
-            $0.bottom.equalToSuperview().inset(16)
+            $0.top.equalTo(voteButton.snp.bottom).offset(12)
             $0.width.equalTo(39.adjustedW)
             $0.height.equalTo(24.adjustedH)
         }

--- a/HARA/HARA/Sources/Scenes/Together/WorryCardCVC.swift
+++ b/HARA/HARA/Sources/Scenes/Together/WorryCardCVC.swift
@@ -54,8 +54,8 @@ class WorryCardCVC: UICollectionViewCell {
         
         let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(40))
         let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, repeatingSubitem: item, count: 1)
-                group.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 10, trailing: 0)
-        //        group.interItemSpacing = .flexible(-16)
+//            group.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 0, bottom: 10, trailing: 0)
+//            group.interItemSpacing = .flexible(-16)
         let section = NSCollectionLayoutSection(group: group)
         section.interGroupSpacing = 10
         section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
@@ -122,6 +122,7 @@ class WorryCardCVC: UICollectionViewCell {
     func setData(title: String, content: String) {
         self.worryTitleLabel.text = title
         self.worryContentLabel.text = content
+        self.worryContentLabel.sizeToFit()
     }
 }
 

--- a/HARA/HARA/Sources/Scenes/Together/WorryCardCVC.swift
+++ b/HARA/HARA/Sources/Scenes/Together/WorryCardCVC.swift
@@ -33,7 +33,7 @@ class WorryCardCVC: UICollectionViewCell {
     private let worryContentLabel = UILabel().then {
         $0.textColor = .hBlack
         $0.font = .haraB2M14
-        $0.text = "1. 동해물과 백두산이 마르고 닳도록 하느님이 보우하사 우리나라 만세 무궁화 삼천리 화려 강산 대한 사람 대한으로 길이 보전하세 2. 남산 위에 저 소나무 철갑을 두른 듯 바람 서리 불변함은 우리 기상일세 무궁화 삼천리 화려 강산 대한 사람 대한으로 길이 보전하세 3. 가을 하늘 공활한데 ..."
+        $0.text = "1. 동해물과 백두산이 마르고 닳도록 하느님이 보우하사 우리나라 만세 무궁화 삼천리 화려 강산 대한 사람 대한으로 길이 보전하세 2. 남산 위에 저 소나무 철갑을 두른 듯 바..."
         $0.numberOfLines = 0
     }
     
@@ -41,7 +41,8 @@ class WorryCardCVC: UICollectionViewCell {
         $0.isScrollEnabled = false
         $0.backgroundColor = .yellow
         $0.showsHorizontalScrollIndicator = false
-        $0.contentInset = UIEdgeInsets.zero
+        $0.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+        
     }
     
     private let voteButton = UIButton().then {
@@ -58,24 +59,28 @@ class WorryCardCVC: UICollectionViewCell {
     private let chatButton = UIButton().then {
         $0.setImage(UIImage(named: "together_chat_icon"), for: .normal)
         var config = UIButton.Configuration.plain()
-        config.imagePadding = 5
+        config.imagePadding = 2
+        config.contentInsets = NSDirectionalEdgeInsets.zero
         $0.configuration = config
+        
         let attribute = [NSAttributedString.Key.font: UIFont.haraSub3R12, NSAttributedString.Key.foregroundColor: UIColor.hGray3 ]
         let attributedTitle = NSAttributedString(string: "10", attributes: attribute)
         $0.setAttributedTitle(attributedTitle, for: .normal)
     }
     
+    private var optionNums = 2
+
     // MARK: - View Life Cycle
     override init(frame: CGRect) {
         super.init(frame: .zero)
-        setvoteOptionCV()
+        setVoteOptionCV()
         setLayout()
         setPressAction()
+        self.contentView.backgroundColor = .green
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-        
     }
     
     // MARK: - Function
@@ -85,70 +90,23 @@ class WorryCardCVC: UICollectionViewCell {
         }
     }
     
-    private func setvoteOptionCV() {
+    private func setVoteOptionCV() {
         voteOptionCV.dataSource = self
         voteOptionCV.delegate = self
         
         voteOptionCV.register(cell: VoteOptionCVC.self, forCellWithReuseIdentifier: VoteOptionCVC.className)
     }
-
     
-    // MARK: - Layout
-    private func setLayout() {
-        contentView.addSubviews([worryCategoryLabel, worryDateLabel, worryTitleLabel, worryContentLabel,voteOptionCV,voteButton, chatButton])
-        
-        worryCategoryLabel.snp.makeConstraints {
-            $0.leading.equalToSuperview().offset(14)
-            $0.top.equalToSuperview().offset(16)
-        }
-        
-        worryDateLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(16)
-            $0.trailing.equalToSuperview().inset(14)
-        }
-        
-        worryTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(worryCategoryLabel.snp.bottom).offset(14)
-            $0.leading.equalToSuperview().offset(14)
-            $0.trailing.equalToSuperview().inset(14)
-        }
-
-        worryContentLabel.snp.makeConstraints {
-            $0.top.equalTo(worryTitleLabel.snp.bottom).offset(8)
-            $0.leading.equalToSuperview().offset(14)
-            $0.trailing.equalToSuperview().inset(14)
-//            $0.height.equalTo(110.adjustedH)
-        }
-        
-        voteOptionCV.snp.makeConstraints {
-            $0.top.equalTo(worryContentLabel.snp.bottom).offset(10)
-            $0.directionalHorizontalEdges.equalToSuperview()
-            $0.height.equalTo(90)
-        }
-        
-        voteButton.snp.makeConstraints {
-            $0.leading.equalToSuperview().offset(15)
-            $0.trailing.equalToSuperview().inset(15)
-            $0.bottom.equalToSuperview().inset(52)
-            $0.height.equalTo(40.adjustedH)
-        }
-
-        chatButton.snp.makeConstraints {
-            $0.trailing.equalToSuperview().inset(15)
-            $0.bottom.equalToSuperview().inset(16)
-//            $0.width.equalTo(39.adjustedW)
-//            $0.height.equalTo(24.adjustedH)
-        }
-        
-        
-        
+    func setCellNums(optionNums: Int) {
+        self.optionNums = optionNums
     }
 }
 
 // MARK: - UICollectionViewDataSource
 extension WorryCardCVC: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return 4
+        print(optionNums)
+        return optionNums
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
@@ -158,15 +116,71 @@ extension WorryCardCVC: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: 312.adjustedW, height: 40.adjustedH)
+        let width = collectionView.frame.width
+        return CGSize(width: width, height: 40.adjustedH)
     }
-    
-    
 }
 
 // MARK: - UICollectionViewDelegateFlowLayout
 extension WorryCardCVC: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return 10
+    }
+}
 
+// MARK: - Layout
+extension WorryCardCVC {
+    private func setLayout() {
+        contentView.addSubviews([worryCategoryLabel, worryDateLabel, worryTitleLabel, worryContentLabel,voteOptionCV,voteButton, chatButton])
+        
+        worryCategoryLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(14)
+            $0.top.equalToSuperview().offset(16)
+            $0.height.equalTo(14)
+        }
+        
+        worryDateLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(16)
+            $0.trailing.equalToSuperview().inset(14)
+            $0.height.equalTo(14)
+        }
+        
+        worryTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(worryCategoryLabel.snp.bottom).offset(14)
+            $0.leading.equalToSuperview().offset(14)
+            $0.trailing.equalToSuperview().inset(14)
+            $0.height.equalTo(19.adjustedH)
+        }
+
+        worryContentLabel.snp.makeConstraints {
+            $0.top.equalTo(worryTitleLabel.snp.bottom).offset(8)
+            $0.leading.equalToSuperview().offset(14)
+            $0.trailing.equalToSuperview().inset(14)
+            $0.height.equalTo(66.adjustedH)
+        }
+        
+        voteOptionCV.snp.makeConstraints {
+            $0.top.equalTo(worryContentLabel.snp.bottom).offset(10)
+            $0.leading.equalToSuperview().offset(11)
+            $0.trailing.equalToSuperview().inset(11)
+//            $0.bottom.equalTo(voteButton.snp.top).inset(10)
+        }
+        
+        voteButton.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(11)
+            $0.trailing.equalToSuperview().inset(11)
+            $0.bottom.equalToSuperview().inset(52)
+            $0.top.equalTo(voteOptionCV.snp.bottom)
+            $0.height.equalTo(40.adjustedH)
+        }
+
+        chatButton.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(15)
+            $0.bottom.equalToSuperview().inset(16)
+            $0.width.equalTo(39.adjustedW)
+            $0.height.equalTo(24.adjustedH)
+        }
+    }
 }
 
 


### PR DESCRIPTION
## 💪 작업한 내용
- TogtherVC에 있는 worryCardCV와 WorryCardCVC 안에 있는 voteOptionCV에 compositionalLayout을 적용하였습니다.
- WorryCardCVC 안에 있는 voteOptionCV의 셀의 개수를 전달해 주기 위해 WorryCardCVC 내부에 optionNums를 만들고 이 값을 변경하는 setCellNums라는 함수를 만들어서 CellForItemAt에서 해당 cell의 setCellNums 메서드를 통해 voteOptionCV에서 그려질 셀 개수를 전달 해주었습니다.


## 💜 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- TogtherVC에서 WorryCardCVC의 높이를 선택지 개수를 의미하는 optionNums라는 변수 값에 따라 조정하기 위해 collectionView의 sizeForItemAt 함수를 통해 개수에 따른 높이 계산을 하려고 했으나 계산이 되지 않아 compositional layout에서 높이를 optionNums에 따라 계산해 주었습니다. 
- 그러나 아직 worryContentLabel의 텍스트 길이에 따라 WorryCVC의 voteOption크기가 동적으로 움직이지 않는 문제가 있는데 이 부분은 차후에 다시 수정해야할 것 같습니다..
- 아직 처리 못한 부분이 있어 주석으로 남기 부분이 있으니 양해 바랍니다.


## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
| 고민 2개 | 고민 4개 |
| - | - |
| ![image](https://user-images.githubusercontent.com/32871014/210854250-97b78785-bdb7-4b0d-8510-d63d58e15fe0.png) | ![image](https://user-images.githubusercontent.com/32871014/210854503-f0523298-4b5f-4de1-af2c-61efa4bffa51.png) |
| 내용 1줄 | 내용 2줄 |
| - | - |
| ![Simulator Screen Shot - iPhone 13 mini - 2023-01-06 at 21 14 42](https://user-images.githubusercontent.com/32871014/211010953-58b26cee-3397-4f7d-88cb-6429fcaaa8b3.png) | ![Simulator Screen Shot - iPhone 13 mini - 2023-01-06 at 21 15 04](https://user-images.githubusercontent.com/32871014/211010981-6e65c4d8-634c-4fa9-b5ca-25de4e6fd63f.png) |






## 🚨 관련 이슈
- Resolved: #12 


<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
